### PR TITLE
リンクを絶対パスから相対パスに変更

### DIFF
--- a/index2.html
+++ b/index2.html
@@ -11,7 +11,7 @@
     <input type="checkbox" name="ただのチェックボックス" value="ボタン１">１<br>
     <input type="checkbox" name="ただのチェックボックス" value="ボタン２">２<br>
     <input type="checkbox" name="ただのチェックボックス" value="ボタン３">３<br>
-   <p><a href="/Users/non/Documents/HTML/index.html">
+   <p><a href="./index.html">
         <button type="button">niniのもとへ帰る</button>
     </a></p>
 </body>


### PR DESCRIPTION
`niniのもとへ帰る`ボタンのリンクが絶対パスになってました！

[絶対パスと相対パス](https://off.tokyo/blog/%e7%b5%b6%e5%af%be%e3%83%91%e3%82%b9%e3%81%a8%e7%9b%b8%e5%af%be%e3%83%91%e3%82%b9%e3%81%be%e3%81%a8%e3%82%81-win-mac/)

この場合、僕の環境だと正常に動作しません。

↓こんな感じになっちゃう
![image](https://user-images.githubusercontent.com/20746608/94682274-a8944d80-035f-11eb-832f-6aecde070135.png)


なので、これを相対パスに変えました。